### PR TITLE
feat: 초기 Spring Security 및 JPA 설정 추가

### DIFF
--- a/src/main/java/com/reservation/reserve/ReservationServiceApplication.java
+++ b/src/main/java/com/reservation/reserve/ReservationServiceApplication.java
@@ -3,9 +3,10 @@ package com.reservation.reserve;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication
-@EnableDiscoveryClient
 public class ReservationServiceApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/reservation/reserve/config/JpaConfig.java
+++ b/src/main/java/com/reservation/reserve/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package com.reservation.reserve.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/src/main/java/com/reservation/reserve/filter/UserContext.java
+++ b/src/main/java/com/reservation/reserve/filter/UserContext.java
@@ -1,0 +1,19 @@
+package com.reservation.reserve.filter;
+
+import com.reservation.reserve.reserve.dto.UserInfo;
+
+public class UserContext {
+    private static final ThreadLocal<UserInfo> currentUser = new ThreadLocal<>();
+    
+    public static void setCurrentUser(String userId, String role) {
+        currentUser.set(new UserInfo(userId, role));
+    }
+    
+    public static UserInfo getCurrentUser() {
+        return currentUser.get();
+    }
+    
+    public static void clear() {
+        currentUser.remove();
+    }
+}

--- a/src/main/java/com/reservation/reserve/filter/UserContextFilter.java
+++ b/src/main/java/com/reservation/reserve/filter/UserContextFilter.java
@@ -1,0 +1,30 @@
+package com.reservation.reserve.filter;
+
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class UserContextFilter implements Filter {
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response,
+                         FilterChain chain) throws IOException, ServletException {
+
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+        String userId = httpRequest.getHeader("X-User-Id");
+        String userRole = httpRequest.getHeader("X-User-Role");
+
+        if (userId != null) {
+            UserContext.setCurrentUser(userId, userRole);
+        }
+
+        try {
+            chain.doFilter(request, response);
+        } finally {
+            UserContext.clear();
+        }
+    }
+}

--- a/src/main/java/com/reservation/reserve/reserve/controller/ReservationController.java
+++ b/src/main/java/com/reservation/reserve/reserve/controller/ReservationController.java
@@ -1,0 +1,11 @@
+package com.reservation.reserve.reserve.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class ReservationController {
+}

--- a/src/main/java/com/reservation/reserve/reserve/domain/ConcertEntity.java
+++ b/src/main/java/com/reservation/reserve/reserve/domain/ConcertEntity.java
@@ -1,0 +1,25 @@
+package com.reservation.reserve.reserve.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ConcertEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+    private LocalDateTime date;
+    private String location;
+
+    @OneToMany(mappedBy = "concert")
+    private List<ReservationEntity> reservations;
+}

--- a/src/main/java/com/reservation/reserve/reserve/domain/ConcertEntity.java
+++ b/src/main/java/com/reservation/reserve/reserve/domain/ConcertEntity.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -21,5 +22,5 @@ public class ConcertEntity {
     private String location;
 
     @OneToMany(mappedBy = "concert")
-    private List<ReservationEntity> reservations;
+    private List<ReservationEntity> reservations = new ArrayList<>();
 }

--- a/src/main/java/com/reservation/reserve/reserve/domain/ReservationEntity.java
+++ b/src/main/java/com/reservation/reserve/reserve/domain/ReservationEntity.java
@@ -9,6 +9,8 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Builder
 @AllArgsConstructor
@@ -33,10 +35,10 @@ public class ReservationEntity {
     private String reserverPhone;
 
     @CreatedDate
-    private String createAt;
+    private LocalDateTime createAt;
 
     @LastModifiedDate
-    private String updateAt;
+    private LocalDateTime updateAt;
 
     private StatusEnum status;
 }

--- a/src/main/java/com/reservation/reserve/reserve/domain/ReservationEntity.java
+++ b/src/main/java/com/reservation/reserve/reserve/domain/ReservationEntity.java
@@ -23,11 +23,11 @@ public class ReservationEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "seat_id")
     private SeatEntity seat;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "concert_id")
     private ConcertEntity concert;
 
@@ -40,5 +40,6 @@ public class ReservationEntity {
     @LastModifiedDate
     private LocalDateTime updateAt;
 
+    @Enumerated(EnumType.STRING)
     private StatusEnum status;
 }

--- a/src/main/java/com/reservation/reserve/reserve/domain/ReservationEntity.java
+++ b/src/main/java/com/reservation/reserve/reserve/domain/ReservationEntity.java
@@ -1,0 +1,42 @@
+package com.reservation.reserve.reserve.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+public class ReservationEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "seat_id")
+    private SeatEntity seat;
+
+    @ManyToOne
+    @JoinColumn(name = "concert_id")
+    private ConcertEntity concert;
+
+    private String reserverName;
+    private String reserverPhone;
+
+    @CreatedDate
+    private String createAt;
+
+    @LastModifiedDate
+    private String updateAt;
+
+    private StatusEnum status;
+}

--- a/src/main/java/com/reservation/reserve/reserve/domain/SeatEntity.java
+++ b/src/main/java/com/reservation/reserve/reserve/domain/SeatEntity.java
@@ -3,6 +3,7 @@ package com.reservation.reserve.reserve.domain;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -21,5 +22,5 @@ public class SeatEntity {
     private String grade;
 
     @OneToMany(mappedBy = "seat")
-    private List<ReservationEntity> reservations;
+    private List<ReservationEntity> reservations = new ArrayList<>();
 }

--- a/src/main/java/com/reservation/reserve/reserve/domain/SeatEntity.java
+++ b/src/main/java/com/reservation/reserve/reserve/domain/SeatEntity.java
@@ -1,0 +1,25 @@
+package com.reservation.reserve.reserve.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SeatEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String seatNumber;
+    private String section;
+    private String grade;
+
+    @OneToMany(mappedBy = "seat")
+    private List<ReservationEntity> reservations;
+}

--- a/src/main/java/com/reservation/reserve/reserve/domain/StatusEnum.java
+++ b/src/main/java/com/reservation/reserve/reserve/domain/StatusEnum.java
@@ -1,0 +1,5 @@
+package com.reservation.reserve.reserve.domain;
+
+enum StatusEnum {
+    SUCCESS, FAILURE, WAITING, REFUND, CANCEL
+}

--- a/src/main/java/com/reservation/reserve/reserve/domain/StatusEnum.java
+++ b/src/main/java/com/reservation/reserve/reserve/domain/StatusEnum.java
@@ -1,5 +1,5 @@
 package com.reservation.reserve.reserve.domain;
 
-enum StatusEnum {
+public enum StatusEnum {
     SUCCESS, FAILURE, WAITING, REFUND, CANCEL
 }

--- a/src/main/java/com/reservation/reserve/reserve/dto/UserInfo.java
+++ b/src/main/java/com/reservation/reserve/reserve/dto/UserInfo.java
@@ -1,0 +1,12 @@
+package com.reservation.reserve.reserve.dto;
+
+import lombok.*;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserInfo {
+
+    private String userId;
+    private String role;
+}

--- a/src/main/java/com/reservation/reserve/reserve/repository/ConcertRepository.java
+++ b/src/main/java/com/reservation/reserve/reserve/repository/ConcertRepository.java
@@ -1,0 +1,9 @@
+package com.reservation.reserve.reserve.repository;
+
+import com.reservation.reserve.reserve.domain.ConcertEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ConcertRepository extends JpaRepository<ConcertEntity, Long> {
+}

--- a/src/main/java/com/reservation/reserve/reserve/repository/ReservationRepository.java
+++ b/src/main/java/com/reservation/reserve/reserve/repository/ReservationRepository.java
@@ -1,0 +1,9 @@
+package com.reservation.reserve.reserve.repository;
+
+import com.reservation.reserve.reserve.domain.ReservationEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReservationRepository extends JpaRepository<ReservationEntity, Long> {
+}

--- a/src/main/java/com/reservation/reserve/reserve/repository/SeatRepository.java
+++ b/src/main/java/com/reservation/reserve/reserve/repository/SeatRepository.java
@@ -1,0 +1,9 @@
+package com.reservation.reserve.reserve.repository;
+
+import com.reservation.reserve.reserve.domain.SeatEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SeatRepository extends JpaRepository<SeatEntity, Long> {
+}

--- a/src/main/java/com/reservation/reserve/reserve/service/ReservationService.java
+++ b/src/main/java/com/reservation/reserve/reserve/service/ReservationService.java
@@ -1,0 +1,20 @@
+package com.reservation.reserve.reserve.service;
+
+import com.reservation.reserve.reserve.repository.ConcertRepository;
+import com.reservation.reserve.reserve.repository.ReservationRepository;
+import com.reservation.reserve.reserve.repository.SeatRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ReservationService {
+
+    private final ReservationRepository reservationRepository;
+    private final ConcertRepository concertRepository;
+    private final SeatRepository seatRepository;
+
+
+}

--- a/src/main/java/com/reservation/reserve/security/SecurityConfig.java
+++ b/src/main/java/com/reservation/reserve/security/SecurityConfig.java
@@ -1,9 +1,26 @@
 package com.reservation.reserve.security;
 
+import com.reservation.reserve.filter.UserContextFilter;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(AbstractHttpConfigurer::disable)
+            .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+            .formLogin(AbstractHttpConfigurer::disable)
+            .httpBasic(AbstractHttpConfigurer::disable)
+                .addFilter(new UserContextFilter());
+        return http.build();
+    }
 
 
 }


### PR DESCRIPTION
## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CI/CD 관련 설정 변경
- [ ] 문서 내용 수정
- [ ] 성능 개선
- [ ] 리팩토링
- [ ] 테스트 코드 추가
- [ ] 기타

## 주요 변경 내용

- Spring Security 의존성을 추가하고, 초기 보안 설정을 구성했습니다.
  - CSRF 비활성화
  - 모든 요청 허용
  - `UserContextFilter` 추가하여 사용자 정보 전송
- JPA 관련 설정을 추가했습니다.
  - `@EnableJpaAuditing` 및 `@EnableJpaRepositories` 활성화
  - 관련 도메인, 리포지토리, 서비스 클래스 추가

## 관련 이슈


