### PR TITLE
feat: AOP 기반 인증 및 예약 취소 로직 개선

### DIFF
--- a/src/main/java/com/reservation/reserve/aop/AuthenticationAspect.java
+++ b/src/main/java/com/reservation/reserve/aop/AuthenticationAspect.java
@@ -1,0 +1,47 @@
+package com.reservation.reserve.aop;
+
+import com.reservation.reserve.filter.UserContext;
+import com.reservation.reserve.reserve.dto.UserInfoDTO;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Arrays;
+
+@Aspect
+@Component
+@Slf4j
+public class AuthenticationAspect {
+
+    @Before("@annotation(requireAuth)")
+    public void checkAuthentication(JoinPoint joinPoint, RequireAuth requireAuth) {
+        log.debug("Authentication check for method: {}", joinPoint.getSignature().getName());
+        
+        UserInfoDTO currentUser = UserContext.getCurrentUser();
+        
+        // 1. 사용자 인증 확인
+        if (requireAuth.required() && currentUser == null) {
+            log.warn("Unauthorized access attempt to method: {}", joinPoint.getSignature().getName());
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증이 필요합니다.");
+        }
+        
+        // 2. 역할 기반 권한 확인
+        if (currentUser != null && requireAuth.roles().length > 0) {
+            String userRole = currentUser.getRole();
+            boolean hasRequiredRole = Arrays.asList(requireAuth.roles()).contains(userRole);
+            
+            if (!hasRequiredRole) {
+                log.warn("Access denied for user {} with role {} to method: {}", 
+                        currentUser.getUserId(), userRole, joinPoint.getSignature().getName());
+                throw new ResponseStatusException(HttpStatus.FORBIDDEN, "권한이 부족합니다.");
+            }
+        }
+        
+        log.debug("Authentication successful for user: {}", 
+                currentUser != null ? currentUser.getUserId() : "anonymous");
+    }
+}

--- a/src/main/java/com/reservation/reserve/aop/RequireAuth.java
+++ b/src/main/java/com/reservation/reserve/aop/RequireAuth.java
@@ -1,0 +1,13 @@
+package com.reservation.reserve.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RequireAuth {
+    String[] roles() default {}; // 필요한 역할들 (선택사항)
+    boolean required() default true; // 인증 필수 여부
+}

--- a/src/main/java/com/reservation/reserve/reserve/controller/ReservationController.java
+++ b/src/main/java/com/reservation/reserve/reserve/controller/ReservationController.java
@@ -1,11 +1,34 @@
 package com.reservation.reserve.reserve.controller;
 
+import com.reservation.reserve.aop.RequireAuth;
+import com.reservation.reserve.filter.UserContext;
+import com.reservation.reserve.reserve.dto.ReservationRequestDto;
+import com.reservation.reserve.reserve.dto.ReservationResponseDto;
+import com.reservation.reserve.reserve.service.ReservationService;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
+@RequestMapping("/api/reservations")
 @RequiredArgsConstructor
-@Slf4j
 public class ReservationController {
+
+    private final ReservationService reservationService;
+
+    @PostMapping
+    @RequireAuth
+    public ResponseEntity<ReservationResponseDto> createReservation(@RequestBody ReservationRequestDto requestDto) {
+        // 인증 체크 로직 제거됨 - 매우 깔끔!
+        String userId = UserContext.getCurrentUser().getUserId();
+        ReservationResponseDto response = reservationService.createReservation(requestDto);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{id}")
+    @RequireAuth(roles = {"ADMIN"}) // 다중 역할 지원
+    public ResponseEntity<Void> deleteReservation(@PathVariable Long id) {
+        reservationService.deleteReservation(id);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/reservation/reserve/reserve/domain/ReservationEntity.java
+++ b/src/main/java/com/reservation/reserve/reserve/domain/ReservationEntity.java
@@ -59,4 +59,8 @@ public class ReservationEntity {
             concert.getReservations().add(this);
         }
     }
+
+    public void updateStatus(StatusEnum status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/com/reservation/reserve/reserve/service/ReservationService.java
+++ b/src/main/java/com/reservation/reserve/reserve/service/ReservationService.java
@@ -4,10 +4,7 @@ import com.reservation.reserve.reserve.domain.ConcertEntity;
 import com.reservation.reserve.reserve.domain.ReservationEntity;
 import com.reservation.reserve.reserve.domain.SeatEntity;
 import com.reservation.reserve.reserve.domain.StatusEnum;
-import com.reservation.reserve.reserve.dto.ConcertDto;
-import com.reservation.reserve.reserve.dto.ReservationRequestDto;
-import com.reservation.reserve.reserve.dto.ReservationResponseDto;
-import com.reservation.reserve.reserve.dto.SeatDto;
+import com.reservation.reserve.reserve.dto.*;
 import com.reservation.reserve.reserve.repository.ConcertRepository;
 import com.reservation.reserve.reserve.repository.ReservationRepository;
 import com.reservation.reserve.reserve.repository.SeatRepository;
@@ -68,7 +65,15 @@ public class ReservationService {
                 saved.getCreateAt(),
                 saved.getStatus()
         );
+    }
 
+    // 취소
+    @Transactional
+    public void deleteReservation(Long id) {
+        ReservationEntity reservation = reservationRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Reservation not found"));
+        reservation.updateStatus(StatusEnum.CANCEL);
+        reservationRepository.save(reservation);
 
     }
 }


### PR DESCRIPTION
## PR 요약

이번 PR에서는 다음과 같은 주요 변경사항을 포함합니다.

1.  **AOP 기반 인증/인가 기능 추가**
    *   `@RequireAuth` 어노테이션과 `AuthenticationAspect`를 도입하여 AOP 기반으로 인증 및 인가 기능을 구현했습니다.
    *   컨트롤러의 인증 로직을 분리하여 코드 중복을 제거하고 가독성을 향상시켰습니다.
    *   `@RequireAuth(roles = {"ADMIN"})`과 같이 특정 역할에 대한 접근 제어 기능을 추가했습니다.

2.  **예약 취소 로직 변경**
    *   예약 취소 시 DB에서 데이터를 삭제하는 대신, 예약 상태(status)를 `CANCEL`로 변경하도록 수정했습니다.
    *   이를 통해 예약 데이터를 보존하면서 취소 상태를 관리할 수 있게 되었습니다.

## 관련 커밋

- feat: AOP를 이용한 인증 및 인가 기능 추가
- refactor: 예약 취소 로직을 상태 변경으로 수정
