### PR TITLE
feat: 예약 조회 기능 추가

### DIFF
--- a/src/main/java/com/reservation/reserve/reserve/controller/ReservationController.java
+++ b/src/main/java/com/reservation/reserve/reserve/controller/ReservationController.java
@@ -34,7 +34,7 @@ public class ReservationController {
 
     // 예약 취소
     @PutMapping("/cancel/{reservationId}")
-    @RequireAuth(roles = {"ADMIN"})
+    @RequireAuth(roles = {"USER", "ADMIN"})
     public ResponseEntity<ApiResponse<Void>>  cancelReservation(@PathVariable("reservationId") Long reservationId) {
 
         reservationService.cancelReservation(reservationId);
@@ -44,6 +44,7 @@ public class ReservationController {
 
     // 예약 단건 조회 (예약 ID로)
     @GetMapping("/check/{reservationId}")
+    @RequireAuth(roles = {"USER"})
     public ResponseEntity<ApiResponse<ReservationResponse>> getReservationById(@PathVariable("reservationId") Long reservationId) {
 
         ReservationResponse response = reservationService.getReservation(reservationId);
@@ -51,7 +52,8 @@ public class ReservationController {
     }
 
     // 특정 이메일(사용자)의 모든 예약 조회
-    @GetMapping("/check/reservation")
+    @GetMapping("/mine")
+    @RequireAuth(roles = {"USER", "ADMIN"})
     public ResponseEntity<ApiResponse<List<ReservationResponse>>> getAllReservationsByUserEmail() {
 
         String email = UserContext.getCurrentUser().getUserId();
@@ -61,6 +63,7 @@ public class ReservationController {
 
     // 특정 콘서트와 좌석에 대한 모든 예약 목록 조회
     @GetMapping("/concert/{concertId}/seat/{seatId}")
+    @RequireAuth(roles = {"ADMIN"})
     public ResponseEntity<ApiResponse<List<ReservationResponse>>> getAllReservationsByConcertIdAndSeatId(
             @PathVariable("concertId") Long concertId,
             @PathVariable("seatId") Long seatId) {

--- a/src/main/java/com/reservation/reserve/reserve/controller/ReservationController.java
+++ b/src/main/java/com/reservation/reserve/reserve/controller/ReservationController.java
@@ -2,6 +2,7 @@ package com.reservation.reserve.reserve.controller;
 
 import com.reservation.reserve.aop.RequireAuth;
 import com.reservation.reserve.filter.UserContext;
+import com.reservation.reserve.reserve.dto.ApiResponse;
 import com.reservation.reserve.reserve.dto.reservation.ReservationCreateRequest;
 import com.reservation.reserve.reserve.dto.reservation.ReservationResponse;
 import com.reservation.reserve.reserve.service.ReservationService;
@@ -9,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/reservations")
@@ -18,22 +21,50 @@ public class ReservationController {
 
     private final ReservationService reservationService;
 
+    // 예약 생성
     @PostMapping("/create")
     @RequireAuth
-    public ResponseEntity<ReservationResponse> createReservation(@RequestBody ReservationCreateRequest requestDto) {
+    public ResponseEntity<ApiResponse<ReservationResponse>> createReservation(@RequestBody ReservationCreateRequest requestDto) {
 
         String email = UserContext.getCurrentUser().getUserId();
         ReservationResponse response = reservationService.createReservation(requestDto, email);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(ApiResponse.success(response));
 
-//        log.info("Create reservation {}", requestDto);
-//        return ResponseEntity.ok().build();
     }
 
-    @PutMapping("/{id}")
+    // 예약 취소
+    @PutMapping("/cancel/{reservationId}")
     @RequireAuth(roles = {"ADMIN"})
-    public ResponseEntity<Void> cancelReservation(@PathVariable Long id) {
-        reservationService.cancelReservation(id);
-        return ResponseEntity.ok().build();
+    public ResponseEntity<ApiResponse<Void>>  cancelReservation(@PathVariable("reservationId") Long reservationId) {
+
+        reservationService.cancelReservation(reservationId);
+        return ResponseEntity.ok(ApiResponse.success());
+
+    }
+
+    // 예약 단건 조회 (예약 ID로)
+    @GetMapping("/check/{reservationId}")
+    public ResponseEntity<ApiResponse<ReservationResponse>> getReservationById(@PathVariable("reservationId") Long reservationId) {
+
+        ReservationResponse response = reservationService.getReservation(reservationId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    // 특정 이메일(사용자)의 모든 예약 조회
+    @GetMapping("/check/reservation")
+    public ResponseEntity<ApiResponse<List<ReservationResponse>>> getAllReservationsByUserEmail() {
+
+        String email = UserContext.getCurrentUser().getUserId();
+        List<ReservationResponse> responses = reservationService.getAllReservationsByEmail(email);
+        return ResponseEntity.ok(ApiResponse.success(responses));
+    }
+
+    // 특정 콘서트와 좌석에 대한 모든 예약 목록 조회
+    @GetMapping("/concert/{concertId}/seat/{seatId}")
+    public ResponseEntity<ApiResponse<List<ReservationResponse>>> getAllReservationsByConcertIdAndSeatId(
+            @PathVariable("concertId") Long concertId,
+            @PathVariable("seatId") Long seatId) {
+        List<ReservationResponse> responses = reservationService.getReservationsByConcertAndSeat(concertId, seatId);
+        return ResponseEntity.ok(ApiResponse.success(responses));
     }
 }

--- a/src/main/java/com/reservation/reserve/reserve/dto/ApiResponse.java
+++ b/src/main/java/com/reservation/reserve/reserve/dto/ApiResponse.java
@@ -5,10 +5,14 @@ public record ApiResponse<T>(
     String message,
     T data
 ) {
+    public static <T> ApiResponse<T> success() {
+        return new ApiResponse<>(true, "성공", null);
+    }
+
     public static <T> ApiResponse<T> success(T data) {
         return new ApiResponse<>(true, "성공", data);
     }
-    
+
     public static <T> ApiResponse<T> success(String message, T data) {
         return new ApiResponse<>(true, message, data);
     }
@@ -16,4 +20,5 @@ public record ApiResponse<T>(
     public static <T> ApiResponse<T> error(String message) {
         return new ApiResponse<>(false, message, null);
     }
+
 }

--- a/src/main/java/com/reservation/reserve/reserve/dto/ApiResponse.java
+++ b/src/main/java/com/reservation/reserve/reserve/dto/ApiResponse.java
@@ -1,9 +1,9 @@
 package com.reservation.reserve.reserve.dto;
 
 public record ApiResponse<T>(
-    boolean success,
-    String message,
-    T data
+        boolean success,
+        String message,
+        T data
 ) {
     public static <T> ApiResponse<T> success() {
         return new ApiResponse<>(true, "성공", null);
@@ -16,9 +16,8 @@ public record ApiResponse<T>(
     public static <T> ApiResponse<T> success(String message, T data) {
         return new ApiResponse<>(true, message, data);
     }
-    
+
     public static <T> ApiResponse<T> error(String message) {
         return new ApiResponse<>(false, message, null);
     }
-
 }

--- a/src/main/java/com/reservation/reserve/reserve/repository/ReservationRepository.java
+++ b/src/main/java/com/reservation/reserve/reserve/repository/ReservationRepository.java
@@ -29,17 +29,26 @@ public interface ReservationRepository extends JpaRepository<ReservationEntity, 
     List<ReservationEntity> findExpiredTempReservations(@Param("now") LocalDateTime now);
 
     /**
-     * 특정 이메일의 예약 목록 조회
-     */
-    List<ReservationEntity> findByReserverEmailOrderByCreateAtDesc(String reserverEmail);
-
-    /**
-     * 특정 콘서트의 예약 목록 조회
-     */
-    List<ReservationEntity> findByConcertIdOrderByCreateAtDesc(Long concertId);
-
-    /**
      * 특정 상태의 예약 개수 조회
      */
     long countByStatus(StatusEnum status);
+
+    /**
+     * 특정 콘서트와 좌석에 대한 임시 예약 존재 여부 확인
+     */
+    boolean existsByConcertIdAndSeatIdAndStatusIn(
+            Long concertId,
+            Long seatId,
+            List<StatusEnum> tempReserved
+    );
+
+    /**
+     * 특정 이메일에 대한 모든 예약 조회 (대소문자 구분 없음)
+     */
+    List<ReservationEntity> findAllByReserverEmail(String email);
+
+    /**
+     * 특정 콘서트와 좌석에 대한 모든 예약 조회
+     */
+    List<ReservationEntity> findAllByConcertIdAndSeatId(Long concertId, Long seatId);
 }

--- a/src/main/java/com/reservation/reserve/reserve/repository/ReservationRepository.java
+++ b/src/main/java/com/reservation/reserve/reserve/repository/ReservationRepository.java
@@ -31,7 +31,7 @@ public interface ReservationRepository extends JpaRepository<ReservationEntity, 
     /**
      * 특정 상태의 예약 개수 조회
      */
-    long countByStatus(StatusEnum status);
+    List<ReservationEntity> findAllByReserverEmailIgnoreCaseOrderByCreateAtDesc(String email);
 
     /**
      * 특정 콘서트와 좌석에 대한 임시 예약 존재 여부 확인
@@ -45,10 +45,30 @@ public interface ReservationRepository extends JpaRepository<ReservationEntity, 
     /**
      * 특정 이메일에 대한 모든 예약 조회 (대소문자 구분 없음)
      */
+    @Query("SELECT r FROM ReservationEntity r " +
+            "JOIN FETCH r.seat " +
+            "JOIN FETCH r.concert c " +
+            "JOIN FETCH c.venue " +
+            "WHERE r.reserverEmail = :email")
     List<ReservationEntity> findAllByReserverEmail(String email);
 
     /**
      * 특정 콘서트와 좌석에 대한 모든 예약 조회
      */
-    List<ReservationEntity> findAllByConcertIdAndSeatId(Long concertId, Long seatId);
+    @Query("SELECT r FROM ReservationEntity r " +
+            "JOIN FETCH r.seat " +
+            "JOIN FETCH r.concert c " +
+            "JOIN FETCH c.venue " +
+            "WHERE r.concert.id = :concertId AND r.seat.id = :seatId")
+    List<ReservationEntity> findAllByConcertIdAndSeatId(@Param("concertId") Long concertId, @Param("seatId") Long seatId);
+
+    /**
+     * 예약 ID로 예약 조회 (좌석, 콘서트, 공연장 정보 포함)
+     */
+    @Query("SELECT r FROM ReservationEntity r " +
+            "JOIN FETCH r.seat " +
+            "JOIN FETCH r.concert c " +
+            "JOIN FETCH c.venue " +
+            "WHERE r.id = :reservationId")
+    Optional<ReservationEntity> findByIdWithDetails(@Param("reservationId") Long reservationId);
 }

--- a/src/main/java/com/reservation/reserve/reserve/repository/ReservationRepository.java
+++ b/src/main/java/com/reservation/reserve/reserve/repository/ReservationRepository.java
@@ -49,8 +49,8 @@ public interface ReservationRepository extends JpaRepository<ReservationEntity, 
             "JOIN FETCH r.seat " +
             "JOIN FETCH r.concert c " +
             "JOIN FETCH c.venue " +
-            "WHERE r.reserverEmail = :email")
-    List<ReservationEntity> findAllByReserverEmail(String email);
+            "WHERE LOWER(r.reserverEmail) = LOWER(:email)")
+    List<ReservationEntity> findAllByReserverEmail(@Param("email") String email);
 
     /**
      * 특정 콘서트와 좌석에 대한 모든 예약 조회
@@ -59,9 +59,9 @@ public interface ReservationRepository extends JpaRepository<ReservationEntity, 
             "JOIN FETCH r.seat " +
             "JOIN FETCH r.concert c " +
             "JOIN FETCH c.venue " +
-            "WHERE r.concert.id = :concertId AND r.seat.id = :seatId")
+            "WHERE r.concert.id = :concertId AND r.seat.id = :seatId " +
+            "ORDER BY r.createAt DESC")
     List<ReservationEntity> findAllByConcertIdAndSeatId(@Param("concertId") Long concertId, @Param("seatId") Long seatId);
-
     /**
      * 예약 ID로 예약 조회 (좌석, 콘서트, 공연장 정보 포함)
      */

--- a/src/main/java/com/reservation/reserve/reserve/service/ReservationService.java
+++ b/src/main/java/com/reservation/reserve/reserve/service/ReservationService.java
@@ -101,6 +101,7 @@ public class ReservationService {
 
 
     // 예약 조회
+    @Transactional(readOnly = true)
     public ReservationResponse getReservation(Long reservationId){
         return reservationRepository.findByIdWithDetails(reservationId)
                 .map(getReservationEntityReservationResponseFunction())


### PR DESCRIPTION

### 변경 내용

- 특정 사용자의 모든 예약 목록을 조회하는 기능을 추가했습니다.
- 특정 콘서트와 좌석에 대한 모든 예약 목록을 조회하는 기능을 추가했습니다.

### 세부 변경 사항

- **`ReservationController`**:
  - `GET /api/reservations/check/reservation`: 특정 사용자의 모든 예약 목록을 조회하는 API 엔드포인트 추가
  - `GET /api/reservations/concert/{concertId}/seat/{seatId}`: 특정 콘서트와 좌석에 대한 모든 예약 목록을 조회하는 API 엔드포인트 추가
- **`ReservationService`**:
  - `getAllReservationsByEmail()`: 특정 사용자의 모든 예약을 조회하는 비즈니스 로직 구현
  - `getReservationsByConcertAndSeat()`: 특정 콘서트와 좌석에 대한 모든 예약을 조회하는 비즈니스 로직 구현
- **`ReservationRepository`**:
  - `findAllByReserverEmail()`: 이메일을 기준으로 예약을 조회하는 쿼리 메소드 추가
  - `findAllByConcertIdAndSeatId()`: 콘서트 ID와 좌석 ID를 기준으로 예약을 조회하는 쿼리 메소드 추가
